### PR TITLE
[React-Componenet | E-SportsAPI] Widget na pagina de updates.

### DIFF
--- a/pages/components/RoundInfo.d.jsx
+++ b/pages/components/RoundInfo.d.jsx
@@ -1,0 +1,73 @@
+import React, { useEffect, useState } from 'react';
+import axios from 'axios';
+import { Card, ListGroup } from 'react-bootstrap';
+import Loading from 'react-loading';
+
+const RoundInfo = ({ gameId }) => {
+  const [data, setData] = useState(null);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    const fetchRoundInfo = async () => {
+      try {
+        const response = await axios.get(
+          `https://api.sportsdata.io/v3/csgo/stats/json/BoxScore/${gameId}?key=167bc5b286e24056b6976303d4d9a68a`
+        );
+        setData(response.data);
+        setLoading(false);
+        console.log('ALO',response.data)
+      } catch (error) {
+        console.error('Error fetching round info:', error);
+      }
+    };
+
+    fetchRoundInfo();
+  }, [gameId]);
+
+  if (loading) {
+    return <Loading type="spin" color="#000" />;
+  }
+
+  if (!data) {
+    return <p>No round information available.</p>;
+  }
+
+  return (
+    <Card className="bg-dark text-white">
+      <Card.Body>
+        <Card.Title>Round Information</Card.Title>
+        <ListGroup>
+          <ListGroup.Item className="bg-dark text-white">
+            <strong>Game ID:</strong> {data.Game.GameId}
+          </ListGroup.Item>
+          <ListGroup.Item className="bg-dark text-white">
+            <strong>Round ID:</strong> {data.Game.RoundId}
+          </ListGroup.Item>
+          <ListGroup.Item className="bg-dark text-white">
+            <strong>Season:</strong> {data.Game.Season}
+          </ListGroup.Item>
+          <ListGroup.Item className="bg-dark text-white">
+            <strong>Season Type:</strong> {data.Game.SeasonType}
+          </ListGroup.Item>
+          <ListGroup.Item className="bg-dark text-white">
+            <strong>Winner:</strong> {data.Game.Winner}
+          </ListGroup.Item>
+          <ListGroup.Item className="bg-dark text-white">
+            <strong>Team A:</strong> {data.Game.TeamAName}
+          </ListGroup.Item>
+          <ListGroup.Item className="bg-dark text-white">
+            <strong>Team A Score:</strong> {data.Game.TeamAScore}
+          </ListGroup.Item>
+          <ListGroup.Item className="bg-dark text-white">
+            <strong>Team B:</strong> {data.Game.TeamBName}
+          </ListGroup.Item>
+          <ListGroup.Item className="bg-dark text-white">
+            <strong>Team B Score:</strong> {data.Game.TeamBScore}
+          </ListGroup.Item>
+        </ListGroup>
+      </Card.Body>
+    </Card>
+  );
+};
+
+export default RoundInfo;

--- a/pages/components/RoundStandings.d.jsx
+++ b/pages/components/RoundStandings.d.jsx
@@ -1,0 +1,41 @@
+import React, { useEffect, useState } from 'react';
+import axios from 'axios';
+
+const RoundStandings = ({ roundId }) => {
+  const [standings, setStandings] = useState(null);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    const fetchStandings = async () => {
+      try {
+        const response = await axios.get(
+          `https://api.sportsdata.io/v3/csgo/scores/json/Standings/${roundId}?key=167bc5b286e24056b6976303d4d9a68a`
+        );
+        setStandings(response.data);
+        setLoading(false);
+      } catch (error) {
+        console.error('Error fetching standings:', error);
+      }
+    };
+
+    fetchStandings();
+  }, [roundId]);
+
+  if (loading) {
+    return <p>Loading standings...</p>;
+  }
+
+  // Render standings data
+  return (
+    <div>
+      <h2>Round Standings</h2>
+      <ul>
+        {standings.map((standing) => (
+          <li key={standing.StandingId}>{standing.Name} - Points: {standing.Points}</li>
+        ))}
+      </ul>
+    </div>
+  );
+};
+
+export default RoundStandings;

--- a/pages/cs/CSGOUpdates.d.jsx
+++ b/pages/cs/CSGOUpdates.d.jsx
@@ -3,6 +3,7 @@ import { Card } from 'react-bootstrap';
 import axios from 'axios';
 import ReactLoading from 'react-loading';
 import Article from '../components/Article.d';
+import CurrentLeagues from '../widgets/CurrentLeagues';
 
 const CSGOUpdates = () => {
   const [csgoNews, setCSGONews] = useState([]);
@@ -90,6 +91,7 @@ const sanitizeContents = (contents) => {
 
   return (
     <div className="main-card-csgo">
+      < CurrentLeagues/>
       <center>
         <h2>CSGO Updates</h2>
       </center>

--- a/pages/leagues/ESLOne.jsx
+++ b/pages/leagues/ESLOne.jsx
@@ -1,0 +1,140 @@
+import React, { useEffect, useState } from 'react';
+import axios from 'axios';
+import { Card, Container, ListGroup, Row, Col, Button } from 'react-bootstrap';
+import Loading from 'react-loading';
+import RoundStandings from '../components/RoundStandings.d';
+import RoundInfo from '../components/RoundInfo.d';
+
+const ESLOneFixtures = () => {
+  const [data, setData] = useState(null);
+  const [loading, setLoading] = useState(true);
+  const [selectedRoundId, setSelectedRoundId] = useState(null);
+
+  useEffect(() => {
+    const fetchData = async () => {
+      try {
+        const response = await axios.get(
+          'https://api.sportsdata.io/v3/csgo/scores/json/CompetitionDetails/100000010?key=167bc5b286e24056b6976303d4d9a68a'
+        );
+        setData(response.data);
+        setLoading(false);
+      } catch (error) {
+        console.error('Error fetching data:', error);
+      }
+    };
+
+    fetchData();
+  }, []);
+
+  if (loading) {
+    return <Loading type="spin" color="#000" />;
+  }
+
+  const shuffledTeams = shuffleArray(data.Teams).slice(0, 7);
+  const shuffledGames = shuffleArray(data.Games).slice(0, 7);
+
+  function shuffleArray(array) {
+    const newArray = [...array];
+    for (let i = newArray.length - 1; i > 0; i--) {
+      const j = Math.floor(Math.random() * (i + 1));
+      [newArray[i], newArray[j]] = [newArray[j], newArray[i]];
+    }
+    return newArray;
+  }
+
+  const uniqueGames = [];
+  const filteredGames = shuffledGames.filter((game) => {
+    if (!uniqueGames.includes(game.GameId)) {
+      uniqueGames.push(game.GameId);
+      return true;
+    }
+    return false;
+  });
+
+  const handleRoundClick = (roundId) => {
+    setSelectedRoundId(roundId);
+  };
+
+  return (
+    <Card className="bg-dark text-white">
+      <Row>
+        <Col>
+          <Card className="bg-dark text-white">
+            <Card.Body>
+              <Card.Title>ESL One Fixtures</Card.Title>
+              <Card.Text>
+                <ListGroup>
+                  <ListGroup.Item className="bg-dark text-white">
+                    <strong>Competition ID:</strong> {data.CompetitionId}
+                  </ListGroup.Item>
+                  <ListGroup.Item className="bg-dark text-white">
+                    <strong>Area ID:</strong> {data.AreaId}
+                  </ListGroup.Item>
+                  <ListGroup.Item className="bg-dark text-white">
+                    <strong>Area Name:</strong> {data.AreaName}
+                  </ListGroup.Item>
+                  <ListGroup.Item className="bg-dark text-white">
+                    <strong>Gender:</strong> {data.Gender}
+                  </ListGroup.Item>
+                  <ListGroup.Item className="bg-dark text-white">
+                    <strong>Type:</strong> {data.Type}
+                  </ListGroup.Item>
+                  <ListGroup.Item className="bg-dark text-white">
+                    <strong>Format:</strong> {data.Format}
+                  </ListGroup.Item>
+                  <ListGroup.Item className="bg-dark text-white">
+                    <strong>Player Stats Coverage:</strong>{' '}
+                    {data.PlayerStatsCoverage ? 'Yes' : 'No'}
+                  </ListGroup.Item>
+                </ListGroup>
+              </Card.Text>
+            </Card.Body>
+          </Card>
+        </Col>
+      </Row>
+      <Row>
+        <Col>
+          <Card className="bg-dark text-white">
+            <Card.Body>
+              <Card.Title>Teams:</Card.Title>
+              <ListGroup>
+                {shuffledTeams.map((team) => (
+                  <ListGroup.Item className="bg-dark text-white" key={team.TeamId}>
+                    {team.Name}
+                  </ListGroup.Item>
+                ))}
+              </ListGroup>
+            </Card.Body>
+          </Card>
+        </Col>
+        <Col>
+          <Card className="bg-dark text-white">
+            <Card.Body>
+              <Card.Title>Games:</Card.Title>
+              {filteredGames.length > 0 ? (
+                <ListGroup>
+                  {filteredGames.map((game) => (
+                    <ListGroup.Item className="bg-dark text-white" key={game.GameId}>
+                      {game.TeamAName} vs {game.TeamBName}
+                      <Button variant="primary" size="sm" className="ml-2" onClick={() => handleRoundClick(game.RoundId)}>
+                        Round {game.RoundId}
+                      </Button>
+                    </ListGroup.Item>
+                  ))}
+                </ListGroup>
+              ) : (
+                <p>No games available.</p>
+              )}
+            </Card.Body>
+          </Card>
+        </Col>
+      </Row>
+
+      {selectedRoundId && (
+        <><RoundInfo roundId={selectedRoundId} /><RoundStandings roundId={selectedRoundId} /></>
+      )}
+    </Card>
+  );
+};
+
+export default ESLOneFixtures;

--- a/pages/widgets/CurrentLeagues.jsx
+++ b/pages/widgets/CurrentLeagues.jsx
@@ -1,0 +1,14 @@
+import React from 'react'
+import ESLOne from '../leagues/ESLOne';
+
+
+const CurrentLeagues = () => {
+  return (
+    <div>CurrentLeagues
+
+        <ESLOne />
+    </div>
+  )
+}
+
+export default CurrentLeagues


### PR DESCRIPTION
![image](https://github.com/Underewarrr/tactical-titans-cs/assets/74227915/8c755784-1c0a-411f-81de-2918083b3a8c)

Adiciona o novo componente ESLOneFixtures ao projeto. 
O componente exibe os detalhes das partidas e equipes do torneio ESL One. Também inclui a funcionalidade de selecionar uma rodada específica e exibir as informações e classificações correspondentes.

Foram feitas alterações no código para atualizar a exibição das partidas, equipes e rodadas, além de adicionar os componentes RoundInfo e RoundStandings.

Essa adição permitirá aos usuários visualizar e acompanhar as informações do torneio ESL One de forma mais conveniente e organizada."